### PR TITLE
Bug: Main User Info Not Stored in Neo4j

### DIFF
--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -4,7 +4,6 @@ dotenv.config();
 export interface TwitterUser {
     id: string;
     name: string;
-    userName: string;
     profile_url: string;
     bio: string;
 }
@@ -34,9 +33,8 @@ export async function fetchFollowings(userName: string, cursor?: string): Promis
         console.log(`Received ${json.followings?.length || 0} followings from TwitterAPI.io`);
 
         const mappedFollowers: TwitterUser[] = (json.followings || []).map((user: any) => ({
-            id: user.id,
+            id: user.userName.toLowerCase(),
             name: user.name,
-            userName: user.userName,
             profile_url: `https://x.com/${user.userName}`,
             bio: user.description || '',
         }));

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -73,8 +73,9 @@ export async function fetchAllFollowings(userName: string): Promise<TwitterUser[
         const response = await fetchFollowings(userName, cursor);
 
         if (response.status !== 'success') {
-            console.error(`API error: ${response.msg}`);
-            break;
+            const errorMsg = `Twitter API error for "${userName}" while fetching followings: ${response.msg}`;
+            console.error(errorMsg);
+            throw new Error(errorMsg);
         }
 
         allFollowings = allFollowings.concat(response.followings);


### PR DESCRIPTION
## Summary

Fixes inconsistencies in how user IDs are stored and ensures full profile data is saved for the main user when syncing followings from Twitter.

## Key Changes

- Use `userName.toLowerCase()` as the canonical ID instead of Twitter's numeric ID.
- Normalize all user IDs to lowercase to prevent duplicate nodes in Neo4j.
- Remove redundant `userName` field from `TwitterUser` objects.
- Ensure the main user’s full profile (name, bio, profile_url) is stored alongside their followings.
- Improve error handling by throwing contextual errors when Twitter API fails.

## Impact

- Prevents duplicate nodes caused by case mismatches (e.g., `HC_Protocol` vs `hc_protocol`).
- Improves consistency and stores complete data for all users in Neo4j.
- No changes to existing API endpoints.


Fixes #5 